### PR TITLE
remove dependencies to rdebock.reboot role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -42,4 +42,3 @@ galaxy_info:
 dependencies:
   - { role: robertdebock.bootstrap, become: true }
   - { role: robertdebock.core_dependencies, become: true }
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -40,4 +40,5 @@ galaxy_info:
     - redhat
 
 dependencies:
-  - robertdebock.reboot
+  - robertdebock.bootstrap
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -40,5 +40,6 @@ galaxy_info:
     - redhat
 
 dependencies:
-  - robertdebock.bootstrap
+  - { role: robertdebock.bootstrap, become: true }
+  - { role: robertdebock.core_dependencies, become: true }
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,4 +41,3 @@ galaxy_info:
 
 dependencies:
   - { role: robertdebock.bootstrap, become: true }
-  - { role: robertdebock.core_dependencies, become: true }

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
 ---
 - robertdebock.bootstrap
-- robertdebock.reboot


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**

The role is already including the reboot role: no need to use it in the dependencies section.
Also, referencing it in the dependencies section force the role to execute, thus rebooting the machine, somewhat not always wanted.
