### PR TITLE
use short inventory name and reload facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for hostname
 
 # The hostname to set. By default whatever the inventory is set to.
-hostname: "{{ inventory_hostname }}"
+hostname: "{{ inventory_hostname_short }}"
 
 # Should the machine be rebooted when the hostname is changed?
 hostname_reboot: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,6 @@
     - reboot
   when:
     - ansible_connection != "docker"
+
+- name: gather ansible facts
+  setup: {}


### PR DESCRIPTION
the configured hostname should not be fully qualified or contain dots. instead the fqdn can be obtained through the resolver (/etc/hosts etc)